### PR TITLE
Date fix safari

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -276,7 +276,7 @@ $(function() {
 $(function() {
   $('.datetime-field').each(function(index, element) {
     var date_text = $(element).text();
-    var date_moment = moment.utc(new Date(date_text));
+    var date_moment = moment(new Date(date_text));
 
     if (!date_moment.isValid()) {
       if (date_text != '') {
@@ -287,6 +287,6 @@ $(function() {
       return;
     }
 
-    $(element).text(date_moment.local().format('D MMM YYYY @ HH:mm:ss'));
+    $(element).text(date_moment.format('D MMM YYYY @ HH:mm:ss'));
   });
 });

--- a/app/models/pomodoro.rb
+++ b/app/models/pomodoro.rb
@@ -89,11 +89,15 @@ class Pomodoro < ApplicationRecord
   end
 
   def start_time_formatted
-    self.start_time.strftime("%x %X")
+    self.start_time.strftime("%x %X %Z")
   end
 
   def end_time_formatted
-    self.end_time.strftime("%x %X")
+    if self.end_time?
+      self.end_time.strftime("%x %X %Z")
+    else
+      self.end_time
+    end
   end
 
   private

--- a/app/models/pomodoro.rb
+++ b/app/models/pomodoro.rb
@@ -88,6 +88,14 @@ class Pomodoro < ApplicationRecord
     end
   end
 
+  def start_time_formatted
+    self.start_time.strftime("%x %X")
+  end
+
+  def end_time_formatted
+    self.end_time.strftime("%x %X")
+  end
+
   private
 
   def calculate_remaining_seconds

--- a/app/models/user_achievement.rb
+++ b/app/models/user_achievement.rb
@@ -9,6 +9,6 @@ class UserAchievement < ApplicationRecord
       date_achieved = self.created_at
     end
 
-    date_achieved
+    date_achieved.strftime("%x %X %Z")
   end
 end

--- a/app/views/pomodoros/index.html.erb
+++ b/app/views/pomodoros/index.html.erb
@@ -62,8 +62,8 @@
             <% @pomodoros.each do |p| %>
               <tr>
                 <td> <%= p.id %> </td>
-                <td class="datetime-field"><%= p.start_time %></td>
-                <td class="datetime-field"><%= p.end_time %></td>
+                <td class="datetime-field"><%= p.start_time_formatted %></td>
+                <td class="datetime-field"><%= p.end_time_formatted %></td>
                 <td><%= seconds_to_timer_str(p.passed_seconds) %></td>
                 <td><%= p.pauses_count %></td>
                 <td><%= p.status %></td>


### PR DESCRIPTION
Removed moment converting to UTC. It seems that parsing the date with js `Date()` already converts from UTC to local.

Thanks JS
![gif](https://media.giphy.com/media/YVeAkNkqPfl5X7MCtv/giphy.gif) 